### PR TITLE
Feature/link as tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# IntelliJ IDE Workspace
+.idea

--- a/index.ts
+++ b/index.ts
@@ -47,7 +47,7 @@ const settings: SettingSchemaDesc[] = [{
   key: "pagesToIgnore",
   description: "Pages to ignore when generating links",
   type: "string",
-  default: "a,b,c,now,later,todo,doing,done,wait,waiting,canceled,cancelled,started,in-progress",
+  default: "a,b,c,card,now,later,todo,doing,done,wait,waiting,canceled,cancelled,started,in-progress",
   title: "Pages to ignore when generating links"
 }]
 logseq.useSettingsSchema(settings)

--- a/index.ts
+++ b/index.ts
@@ -47,7 +47,7 @@ const settings: SettingSchemaDesc[] = [{
   key: "pagesToIgnore",
   description: "Pages to ignore when generating links",
   type: "string",
-  default: "TODO,A,B,C",
+  default: "a,b,c,now,later,todo,doing,done,wait,waiting,canceled,cancelled,started,in-progress",
   title: "Pages to ignore when generating links"
 }]
 logseq.useSettingsSchema(settings)

--- a/index.ts
+++ b/index.ts
@@ -53,12 +53,12 @@ const settings: SettingSchemaDesc[] = [{
 logseq.useSettingsSchema(settings)
 async function getPages() {
   const pagesToIgnore = logseq.settings?.pagesToIgnore.split(',').map(x => x.toUpperCase().trim())
-  const query = `[:find (pull ?p [*]) :where [?p :block/uuid ?u][?p :block/name]]`
+  const query = `[:find (pull ?p [*]) :where [?p :block/uuid ?u][?p :block/original-name]]`
   logseq.DB.datascriptQuery(query).then(
     (results) => {
       pageList = results
-        .filter(x => !pagesToIgnore.includes(x[0].name.toUpperCase()))
-        .map(x => x[0].name)
+        .filter(x => !pagesToIgnore.includes(x[0]['original-name'].toUpperCase()))
+        .map(x => x[0]['original-name'])
     }
   )
 }
@@ -86,9 +86,9 @@ async function parseBlockForLink(d: string) {
         content = content.replaceAll(regex, (match) => {
           const hasSpaces = /\s/g.test(match)
           if (logseq.settings?.parseAsTags || (logseq.settings?.parseSingleWordAsTag && !hasSpaces)) {
-            return hasSpaces ? `#[[${match}]]` : `#${match}`
+            return hasSpaces ? `#[[${value}]]` : `#${value}`
           }
-          return `[[${match}]]`
+          return `[[${value}]]`
         })
         logseq.Editor.updateBlock(block.uuid, `${content}`)
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,77 @@
+{
+    "compilerOptions": {
+        /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+        /* Basic Options */
+        // "incremental": true,                   /* Enable incremental compilation */
+        "target": "ESNext",
+        /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+        "module": "ESNext",
+        /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+        // "lib": [],                             /* Specify library files to be included in the compilation. */
+        // "allowJs": true,                       /* Allow javascript files to be compiled. */
+        // "checkJs": true,                       /* Report errors in .js files. */
+        // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+        // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+        // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+        // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+        // "outFile": "./",                       /* Concatenate and emit output to single file. */
+        // "outDir": "./",                        /* Redirect output structure to the directory. */
+        // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+        // "composite": true,                     /* Enable project compilation */
+        // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+        // "removeComments": true,                /* Do not emit comments to output. */
+        "noEmit": true,
+        /* Do not emit outputs. */
+        // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+        // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+        // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+        /* Strict Type-Checking Options */
+        // "strict": true,
+        /* Enable all strict type-checking options. */
+        // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+        // "strictNullChecks": true,              /* Enable strict null checks. */
+        // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+        // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+        // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+        // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+        // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+        /* Additional Checks */
+        // "noUnusedLocals": true,                /* Report errors on unused locals. */
+        // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+        // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+        // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+        /* Module Resolution Options */
+        "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+        // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+        // "typeRoots": [],                       /* List of folders to include type definitions from. */
+        // "types": [],                           /* Type declaration files to be included in compilation. */
+        "allowSyntheticDefaultImports": true,
+        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        "esModuleInterop": true,
+        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+        // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+        // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+        /* Source Map Options */
+        // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+        // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+        // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+        /* Experimental Options */
+        // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+        // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+        /* Advanced Options */
+        "skipLibCheck": true,
+        /* Skip type checking of declaration files. */
+        "forceConsistentCasingInFileNames": true
+        /* Disallow inconsistently-cased references to the same file. */
+    }
+}


### PR DESCRIPTION
Sorry, I got a bit carried away.

Let me know if this needs any changes.

Adds the following configuration options:
- enableAutoParse: Persists the configuration for this, so that it can be left on or off as desired
- parseSingleWordAsTag: If enabled, converts single word pages into tags
- parseAsTags: If enabled, all links are converted into tags
- pagesToIgnore: A comma-separated list of pages to ignore (we might want to check what the default should be here

I tidied up some of the code as well. We can change anything you don't like, but as it stands this plugin is perfect for me with these changes.

I also updated the .gitignore to include IntelliJ files and added a tsconfig.json to help with linting (It is set to be permissive but I change it locally for better linting). 