### PR TITLE
Fix bug with inline code and code block replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,38 @@
->If this plugin helps you, I'd really appreciate your support. You can [buy me a coffee here. ](https://www.buymeacoffee.com/sawhney17)
---- 
+> If this plugin helps you, I'd really appreciate your support. You can [buy me a coffee here. ](https://www.buymeacoffee.com/sawhney17)
+
+---
+
 # Automatic Linker for Logseq
 
-A plugin to automatically create links while typing. 
+A plugin to automatically create links while typing.
 
 Requires logseq version 0.67 and above to function properly
 ![Screen Recording 2022-05-11 at 8 03 24 AM](https://user-images.githubusercontent.com/80150109/167770331-a89d9939-888f-466c-9738-29daa263e724.gif)
 
-
 ## Instructions
+
 1. Install the plugin from the marketplace
-2. Use the keyboard shortcut <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> to enable automatic mode 
-3. Else, Use <kbd>Command</kbd>+<kbd>P</kbd> to parse the current block 
+2. Use the keyboard shortcut <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> to enable automatic mode
+3. Else, Use <kbd>Command</kbd>+<kbd>P</kbd> to parse the current block
 4. Else, right click the bullet and click parse block for links
 5. Watch as the links are automatically made!!
 
 ## Customization
+
 - Ignoring specific pages from being auto linked
   1. Add a property. `automatic-ignore:: true`
   2. This page, and all its aliases, will now be ignored from auto linking! (Thanks [@trashhalo](https://github.com/trashhalo))
+
+## Development
+
+1. Fork the repo.
+2. Run `yarn install && yarn run dev` to build the dev version.
+3. Open Logseq and navigate to the plugins dashboard: `t` `p`.
+4. Click `Load unpacked plugin button`, then select the repo directory to load it.
+
+After every change you make in the code:
+
+1. Run `yarn run dev` to rebuild the dev version.
+2. Open Logseq and navigate to the plugins dashboard: `t` `p`.
+3. Find the plugin and click on "Reload".
+4. Ignore the error messages about keyboard shortcut conflicts.

--- a/index.ts
+++ b/index.ts
@@ -130,6 +130,9 @@ const parseForRegex = (s: string) => {
     // .replaceAll(" ", "\\s+");
 };
 
+const CODE_BLOCK_PLACEHOLDER = "wxhkjsdkdksjldfkjhsdfkncncn"
+const INLINE_CODE_PLACEHOLDER = "zmkjfndkfhkfhjkdfkjdlhfkdljfkjd"
+
 
 async function parseBlockForLink(d: string) {
   if (d != null) {
@@ -148,12 +151,12 @@ async function parseBlockForLink(d: string) {
     content = content.replaceAll(/```(.|\n)*```/gim, (match) => {
       // reversalIndexTracker++;
       codeblockReversalTracker.push(match);
-      return "wxhkjs";
+      return CODE_BLOCK_PLACEHOLDER;
     });
 
     content = content.replaceAll(/(?=`)`(?!`)[^`]*(?=`)`(?!`)/g, (match) => {
       inlineCodeReversalTracker.push(match);
-      return "zmkjfnd";
+      return INLINE_CODE_PLACEHOLDER;
     });
 
     //rmeove first and last letter from the result
@@ -188,16 +191,16 @@ async function parseBlockForLink(d: string) {
           // setTimeout(() => { inProcess = false }, 300)
         }
       }
-      //if value is chinese 
+      //if value is chinese
     });
     // logseq.Editor.updateBlock(block.uuid, content)
 
     //re add the escaped content
     codeblockReversalTracker?.forEach((value, index) => {
-      content = content.replaceAll(`wxhkjsdkdksjldfkjhsdfkncncn`, value);
+      content = content.replace(CODE_BLOCK_PLACEHOLDER, value);
     });
     inlineCodeReversalTracker?.forEach((value, index) => {
-      content = content.replaceAll(`zmkjfndkfhkfhjkdfkjdlhfkdljfkjd`, value);
+      content = content.replace(INLINE_CODE_PLACEHOLDER, value);
     });
 
     if (needsUpdate) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,10 +75,10 @@
   dependencies:
     "@lezer/common" "^0.15.0"
 
-"@logseq/libs@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@logseq/libs/-/libs-0.0.2.tgz#5d139e89ccd791276a76a316762df50ede097c77"
-  integrity sha512-cRABnS/UbrT+Pw7LkkYemX1RO5qgG2txNoZqZ3x1uFD8AXdv2hhpkxV7GNF/XHttYi1tcBjaFwW7pMD87Iyp/w==
+"@logseq/libs@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@logseq/libs/-/libs-0.0.6.tgz#a8270d5bd71bccf13455634f9a2aac2572a0b935"
+  integrity sha512-0Fv+Wdno5m0EA9xW6tRRvoKNPAF5nznpi6A1bBjh8aq4XMt7rGvhHbsH+u84/nswCYlce3t2Q/ei8CRK8iWbdw==
   dependencies:
     csstype "3.0.8"
     debug "4.3.1"


### PR DESCRIPTION
# Summary/context

All my inline code `written like this in Logseq` was being removed and replaced by `zmkjfnd`.

# Changes

- fix: bug with inline code and code blocks
- refactor: use constants instead of string literals
- docs: add "Development" section to README
