### PR TITLE
feat: smart case when creating page links

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -68,32 +68,37 @@ export function replaceContentWithPageLinks(
   });
 
   let needsUpdate = false;
-  allPages.forEach((value) => {
+  allPages.forEach((page) => {
     const regex = new RegExp(
       `(\\w*(?<!\\[{2}[^[\\]]*)\\w*(?<!\\#)\\w*(?<!\\w+:\\/\\/\\S*))\\b(${parseForRegex(
-        value
+        page
       )})(?![^[\\]]*\\]{2})\\b`,
       "gi"
     );
     // console.log({LogseqAutomaticLinker: "value", value})
     const chineseRegex = new RegExp(
-      `(?<!\\[)${parseForRegex(value)}(?!\\])`,
+      `(?<!\\[)${parseForRegex(page)}(?!\\])`,
       "gm"
     );
-    if (value.match(/^[\u4e00-\u9fa5]{0,}$/gm)) {
+    if (page.match(/^[\u4e00-\u9fa5]{0,}$/gm)) {
       content = content.replaceAll(
         chineseRegex,
-        parseAsTags ? `#${value}` : `[[${value}]]`
+        parseAsTags ? `#${page}` : `[[${page}]]`
       );
       needsUpdate = true;
-    } else if (value.length > 0) {
-      if (content.toUpperCase().includes(value.toUpperCase())) {
+    } else if (page.length > 0) {
+      if (content.toUpperCase().includes(page.toUpperCase())) {
         content = content.replaceAll(regex, (match) => {
           const hasSpaces = /\s/g.test(match);
+
+          // If page is lowercase, keep the original case of the input (match);
+          // Otherwise, use the page case
+          let whichCase = page == page.toLowerCase() ? match : page;
+
           if (parseAsTags || (parseSingleWordAsTag && !hasSpaces)) {
-            return hasSpaces ? `#[[${value}]]` : `#${value}`;
+            return hasSpaces ? `#[[${whichCase}]]` : `#${whichCase}`;
           }
-          return `[[${value}]]`;
+          return `[[${whichCase}]]`;
         });
         needsUpdate = true;
         // setTimeout(() => { inProcess = false }, 300)

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -22,7 +22,7 @@ describe("replaceContentWithPageLinks()", () => {
       false
     );
     expect(content).toBe(
-      "[[page]] before\n`page inside inline code`\n[[page]] between\n`another page inline`\n[[page]] after"
+      "[[Page]] before\n`page inside inline code`\n[[page]] between\n`another page inline`\n[[page]] after"
     );
     expect(update).toBe(true);
   });
@@ -92,5 +92,43 @@ describe("replaceContentWithPageLinks()", () => {
     );
     expect(content).toBe("This text doesn't have any links to be parsed");
     expect(update).toBe(false);
+  });
+
+  it("should keep the original input case for lowercase pages", () => {
+    let [content, update] = replaceContentWithPageLinks(
+      ["when", "for pages", "because", "links", "logseq"],
+      `When creating links, the original case that was typed should be preserved
+      for PAGES that only have lowercase words.
+      Because logSEQ LINKS are case-insensitive anyway.`,
+      false,
+      false
+    );
+    expect(content).toBe(
+      `[[When]] creating [[links]], the original case that was typed should be preserved
+      [[for PAGES]] that only have lowercase words.
+      [[Because]] [[logSEQ]] [[LINKS]] are case-insensitive anyway.`
+    );
+    expect(update).toBe(true);
+  });
+
+  it("should disregard the input case and use the page case for uppercase, title case and mixed case pages", () => {
+    let [content, update] = replaceContentWithPageLinks(
+      ["John Doe", "Mary Doe", "ANYWAY", "Logseq", "But"],
+      `When creating links, the page case should be used when it's not lowercase.
+      So things like names are properly capitalised even when typed in lowercase: john doe, mary doe.
+      logseq LINKS are case-insensitive anyway.
+      but LOGSEQ will keep the case of pages that are uppercase or title case when displaying,
+      even if you type them in lowercase`,
+      false,
+      false
+    );
+    expect(content).toBe(
+      `When creating links, the page case should be used when it's not lowercase.
+      So things like names are properly capitalised even when typed in lowercase: [[John Doe]], [[Mary Doe]].
+      [[Logseq]] LINKS are case-insensitive [[ANYWAY]].
+      [[But]] [[Logseq]] will keep the case of pages that are uppercase or title case when displaying,
+      even if you type them in lowercase`
+    );
+    expect(update).toBe(true);
   });
 });


### PR DESCRIPTION
⚠️ Depends on this other pull request to be merged first: https://github.com/sawhney17/logseq-automatic-linker/pull/32 ⚠️ 

- lowercase pages: keep the original case that was typed
- uppercase/mixed case pages: use the case from the page (e.g.: proper
  names, company names, etc.)