### PR TITLE
fix: Aliases are not added to the page list.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -106,7 +106,7 @@ async function getPages() {
       )
       .map((x) => x[0]["original-name"])
       .filter((x) => x);
-    pageList.concat(await fetchAliases());
+    pageList = pageList.concat((await fetchAliases()).flat());
     //Reverse sort pagelist on the basis of length so that longer page names are matched first
     pageList.sort((a, b) => b.length - a.length);
     console.log({ LogseqAutomaticLinker: "getPages", results, pageList });


### PR DESCRIPTION
`pageList.concat` won't change `pageList` itself, instead, it generates a new array.