### PR TITLE
fix: replace word boundary regex to unicode supported alternative

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -70,9 +70,9 @@ export function replaceContentWithPageLinks(
   let needsUpdate = false;
   allPages.forEach((page) => {
     const regex = new RegExp(
-      `(\\w*(?<!\\[{2}[^[\\]]*)\\w*(?<!\\#)\\w*(?<!\\w+:\\/\\/\\S*))\\b(${parseForRegex(
+      `(\\w*(?<!\\[{2}[^[\\]]*)\\w*(?<!\\#)\\w*(?<!\\w+:\\/\\/\\S*))(?<=[\\s,.:;"']|^)(${parseForRegex(
         page
-      )})(?![^[\\]]*\\]{2})\\b`,
+      )})(?![^[\\]]*\\]{2})(?=[\\s,.:;"']|$)`,
       "gi"
     );
     // console.log({LogseqAutomaticLinker: "value", value})

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -131,4 +131,16 @@ describe("replaceContentWithPageLinks()", () => {
     );
     expect(update).toBe(true);
   });
+
+  it("should detect Unicode links", () => {
+    let [content, update] = replaceContentWithPageLinks(
+      ["가나다"],
+      `This block implicitly contains unicode words like 가나다.`,
+      false,
+      false
+    );
+    expect(content).toBe(
+      `This block implicitly contains unicode words like [[가나다]].`
+    );
+  });
 });


### PR DESCRIPTION
Reference: https://shiba1014.medium.com/regex-word-boundaries-with-unicode-207794f6e7ed

Close #16 