### PR TITLE
fix: Allow manually parsing block even when auto linking is enabled

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -186,9 +186,7 @@ const main = async () => {
     { binding: logseq.settings?.parseSingleBlockKeybinding },
     (e) => {
       getPages();
-      if (!logseq.settings?.enableAutoParse) {
-        parseBlockForLink(e.uuid);
-      }
+      parseBlockForLink(e.uuid);
     }
   );
 };


### PR DESCRIPTION
## Description

Expected behavior when manually triggering parsing of a block is for the block to be parsed even when auto linking is enabled. This PR changes the behavior of the plugin to allow the user to trigger parsing of a block at will regardless of the state of auto parsing.