### PR TITLE
test(chinese): Attempt at adding tests for the chinese regex match

### DIFF
--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -143,4 +143,28 @@ describe("replaceContentWithPageLinks()", () => {
       `This block implicitly contains unicode words like [[가나다]].`
     );
   });
+
+  it("should replace links made up of CJKV characters", () => {
+    let [content, update] = replaceContentWithPageLinks(
+      ["书架"],
+      `This block implicitly contains CJKV words like 书架.`,
+      false,
+      false
+    );
+    expect(content).toBe(
+      `This block implicitly contains CJKV words like [[书架]].`
+    );
+  });
+
+  it("should replace links made up of CJKV characters with tags", () => {
+    let [content, update] = replaceContentWithPageLinks(
+      ["书架"],
+      `This block implicitly contains CJKV words like 书架.`,
+      true,
+      false
+    );
+    expect(content).toBe(
+      `This block implicitly contains CJKV words like #书架.`
+    );
+  });
 });


### PR DESCRIPTION
## Problem
I noticed while testing #72 that this piece of code:

```typescript
if (page.match(/^[\u4e00-\u9fa5]{0,}$/gm)) {
  content = content.replaceAll(
    chineseRegex,
    parseAsTags ? `#${page}` : `[[${page}]]`
  );
  needsUpdate = true;
}
```
was not actually tested anywhere.

## Solution
This is my attempt at adding a couple of tests for this secton of code.

## Apologies and Disclaimer
However, I am not a native Chinese, Japanese, Korean or Vietnamese speaker, and this was a best guess based on the official [unicode table](https://unicode.org/charts/PDF/U4E00.pdf) and the Cabridge English <-> Chinese (Simplified) dictionary, so if this is not right for any reason, please feel free to edit the PR and/or feedback here please! The aim here is to avoid any regression from getting introduced in the future.


## Question
I also noticed that the unicode tables go all the way to `\u9fff` for CJKV characters/ideographs. Should we expand the scope of the `chineseRegex` to match this? 