### PR TITLE
fix(markdown-links): Allowing for escaped square brackets in markdown links

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -61,7 +61,7 @@ export function replaceContentWithPageLinks(
 
   // Broken Markdown links with nested pages won't be detected by this regex and have to be fixed manually.
   // Example: [[[page]] This is a broken Markdown link](http://example.com)
-  content = content.replaceAll(/\[[^\[\]]+\]\([^\(\)]+\)/g, (match) => {
+  content = content.replaceAll(/\[(([^\[\]]|\\\[|\\\])+)\]\(.*\)/g, (match) => {
     markdownLinkTracker.push(match);
     console.debug({ LogseqAutomaticLinker: "Markdown link found", match });
     return MARKDOWN_LINK_PLACEHOLDER;

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -46,15 +46,17 @@ describe("replaceContentWithPageLinks()", () => {
 
   it("should preserve Markdown links", () => {
     let [content, update] = replaceContentWithPageLinks(
-      ["page", "link"],
+      ["page", "link", "Logseq"],
       `This page has a link: [page link will not be touched](http://a.com)
-      [another page](http://b.com) also with a link`,
+      [another page](http://b.com) also with a link
+      [\\[This\\] is a Logseq page](https://logseq.com)`,
       false,
       false
     );
     expect(content).toBe(
       `This [[page]] has a [[link]]: [page link will not be touched](http://a.com)
-      [another page](http://b.com) also with a [[link]]`
+      [another page](http://b.com) also with a [[link]]
+      [\\[This\\] is a Logseq page](https://logseq.com)`
     );
     expect(update).toBe(true);
   });


### PR DESCRIPTION
This PR should fix #56

## Problem
When a markdown link had escaped square brackets, the regex was not identifying that as being part of the markdown link. So a link such as `[\[This\] is a Logseq page](https://logseq.com)` was not being recgnized as a markdown link.

## Solution
Set the Regex to also accept `\\\[` and `\\\]` which resolve to `\[` and `\]` respectively.