### PR TITLE
ci(publish): Update plugin name and node version in GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
       - '*' # Push events to matching any tag format, i.e. 1.0, 20.15.10
 
 env:
-  PLUGIN_NAME: logseq-starter-plugin
+  PLUGIN_NAME: logseq-automatic-linker
 
 jobs:
   build:
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '16.x' # You might need to adjust this value to your own version
+          node-version: '20.x' # You might need to adjust this value to your own version
       - name: Build
         id: build
         run: |


### PR DESCRIPTION
I noticed the release files were being published under the wrong name, so this commit fixes that. Also, NodeJS 16 has now reached end of life, with the current LTS version of NodeJS which is v20.x.