### PR TITLE
fix(logseq 10.5): Automatic link on pressing enter with Logseq 10.5

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -149,7 +149,7 @@ const main = async () => {
   getPages();
   dateFormat = (await logseq.App.getUserConfigs()).preferredDateFormat;
   logseq.DB.onChanged((e) => {
-    if (e.txMeta?.outlinerOp == "insertBlocks") {
+    if (e.txMeta?.outlinerOp == "insert-blocks") {
       if (logseq.settings?.enableAutoParse) {
         blockArray?.forEach(parseBlockForLink);
       }

--- a/index.ts
+++ b/index.ts
@@ -149,7 +149,7 @@ const main = async () => {
   getPages();
   dateFormat = (await logseq.App.getUserConfigs()).preferredDateFormat;
   logseq.DB.onChanged((e) => {
-    if (e.txMeta?.outlinerOp == "insert-blocks") {
+    if (e.txMeta?.outlinerOp == "insert-blocks" || e.txMeta?.outlinerOp == "insertBlocks") {
       if (logseq.settings?.enableAutoParse) {
         blockArray?.forEach(parseBlockForLink);
       }


### PR DESCRIPTION
### Problem
The automatic linking of pages didn't work. The Logseq team probably change the insertBlocks variable to insert-blocks. So the if condition stopped working.

### Solution
change the comparison string