### PR TITLE
Improve code block and inline code detection

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -55,13 +55,13 @@ export function replaceContentWithPageLinks(
   const markdownLinkTracker = [];
   const customQueryTracker = [];
 
-  content = content.replaceAll(/```([^`]|\n)*```/gim, (match) => {
+  content = content.replaceAll(/```[\s\S]*?```/g, (match) => {
     codeblockReversalTracker.push(match);
     console.debug({ LogseqAutomaticLinker: "code block found", match });
     return CODE_BLOCK_PLACEHOLDER;
   });
 
-  content = content.replaceAll(/(?=`)`(?!`)[^`]*(?=`)`(?!`)/g, (match) => {
+  content = content.replaceAll(/`[^`]*`/g, (match) => {
     inlineCodeReversalTracker.push(match);
     console.debug({ LogseqAutomaticLinker: "inline code found", match });
     return INLINE_CODE_PLACEHOLDER;

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -4,12 +4,12 @@ describe("replaceContentWithPageLinks()", () => {
   it("should preserve code blocks", () => {
     let [content, update] = replaceContentWithPageLinks(
       ["page"],
-      "page before ```\npage within code block\n```\npage between\n```\nanother page within code block\n```\npage after",
+      "page before ```\npage within code block\n```\npage between\n```\nanother page within code block```\nand finally\n```\nwith `single` backticks and page within\n```\npage after",
       false,
       false
     );
     expect(content).toBe(
-      "[[page]] before ```\npage within code block\n```\n[[page]] between\n```\nanother page within code block\n```\n[[page]] after"
+      "[[page]] before ```\npage within code block\n```\n[[page]] between\n```\nanother page within code block```\nand finally\n```\nwith `single` backticks and page within\n```\n[[page]] after"
     );
     expect(update).toBe(true);
   });
@@ -17,12 +17,12 @@ describe("replaceContentWithPageLinks()", () => {
   it("should preserve inline code", () => {
     let [content, update] = replaceContentWithPageLinks(
       ["page"],
-      "Page before\n`page inside inline code`\npage between\n`another page inline`\npage after",
+      "Page before\n`page inside inline code`\npage between\n`another page inline`\n`but not page if inline\nblock is split between newlines`\npage after",
       false,
       false
     );
     expect(content).toBe(
-      "[[Page]] before\n`page inside inline code`\n[[page]] between\n`another page inline`\n[[page]] after"
+      "[[Page]] before\n`page inside inline code`\n[[page]] between\n`another page inline`\n`but not page if inline\nblock is split between newlines`\n[[page]] after"
     );
     expect(update).toBe(true);
   });


### PR DESCRIPTION
The PR handles 2 additional edge cases for code block and inline code detection.

It also resolves an **Inefficient regular expression** code scan alert (see screenshot below) detected by [enabling Code Scanning](https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning#configuring-default-setup-for-a-repository) in my clone of your repository.

PS - thank you for all of your amazing contributions!

![image](https://github.com/sawhney17/logseq-automatic-linker/assets/66134/eee81436-1454-4209-9f7d-8107ea37e26f)
