### PR TITLE
fix: Prevent multiple executions of db.onChanged callback

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -149,6 +149,7 @@ const main = async () => {
   getPages();
   dateFormat = (await logseq.App.getUserConfigs()).preferredDateFormat;
   logseq.DB.onChanged((e) => {
+    if (e.txMeta?.["skipRefresh?"] === true) return;
     if (e.txMeta?.outlinerOp == "insert-blocks" || e.txMeta?.outlinerOp == "insertBlocks") {
       if (logseq.settings?.enableAutoParse) {
         blockArray?.forEach(parseBlockForLink);


### PR DESCRIPTION
### Issue
When we change a block, logseq.DB.onChanged gets called multiple (3) times. 

### Solution
This commit adds a guard clause to prevent executing the callback function multiple times for a single block change.